### PR TITLE
Support 'size' mode for sunburst

### DIFF
--- a/nvd3-sunburst.html
+++ b/nvd3-sunburst.html
@@ -109,6 +109,16 @@ Data Format:
           value: function() {
             return  nv.models.sunburstChart();
           }
+        },
+        mode: {
+          type: String,
+          value: 'count',
+          observer: 'modeChanged'
+        }
+      },
+      modeChanged: function (newvalue) {
+        if (this._chart) {
+          this._chart.mode(newvalue);
         }
       }
     });


### PR DESCRIPTION
The sample data for the sunburst has 'size' properties but mode has to be changed to 'size' for this to have an effect.