### PR TITLE
Simplify flexSize (+misc)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#~1.1.4",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.1.5"
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.1.5",
+    "iron-flex-layout": "polymerelements/iron-flex-layout#^1.3.1"
   }
 }

--- a/demo/nvd3-donut.html
+++ b/demo/nvd3-donut.html
@@ -7,10 +7,13 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>nvd3-donut Demo</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout-classes.html">
   <link rel="import" href="../nvd3-donut.html">
 </head>
 
 <body unresolved>
+
+  <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
 
   <p>An example of
     <code>&lt;nvd3-donut&gt;</code>:</p>
@@ -18,9 +21,16 @@
   <nvd3-donut title="My Donut!" height="400" auto-resize show-labels show-legend donut-ratio="0.25" grow-on-hover labels-outside>
   </nvd3-donut>
 
+  <div style="width: 100%">
+    <div class="horizontal layout flex center-center">
+      <nvd3-donut class="flex" flex-size title="My flex Donut!" auto-resize show-labels show-legend grow-on-hover labels-outside>
+      </nvd3-donut>
+    </div>
+  </div>
+
   <script>
-    var el = document.querySelector('nvd3-donut');
-    el.data = [{
+    var el = document.querySelectorAll('nvd3-donut');
+    el[0].data = [{
       "label": "One",
       "value": 29.765957771107
     }, {
@@ -46,7 +56,9 @@
       "value": 5.1387322875705
     }];
 
-    el.addEventListener('slice-selected', function (e) {
+    el[1].data = el[0].data;
+
+    el[0].addEventListener('slice-selected', function (e) {
       console.log('slice-selected');
     });
   </script>

--- a/demo/nvd3-sunburst.html
+++ b/demo/nvd3-sunburst.html
@@ -7,22 +7,30 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>nvd3-sunburst Demo</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout-classes.html">
   <link rel="import" href="../nvd3-sunburst.html">
 </head>
 
 <body unresolved>
 
+  <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
+
   <p>An example of
     <code>&lt;nvd3-sunburst&gt;</code>:</p>
 
-  <nvd3-sunburst height="400" auto-resize>
+  <nvd3-sunburst height="400" auto-resize></nvd3-sunburst>
 
-  </nvd3-sunburst>
+  <div style="width: 100%">
+    <div class="horizontal layout flex center-center">
+      <nvd3-sunburst class="flex" flex-size title="My flex sunburst!" auto-resize show-labels>
+      </nvd3-sunburst>
+    </div>
+  </div>
 
   <script>
-    var el = document.querySelector('nvd3-sunburst');
+    var el = document.querySelectorAll('nvd3-sunburst');
 
-    el.data =   [{
+    el[0].data =   [{
             "name": "flare",
             "children": [
                 {
@@ -402,6 +410,7 @@
                 }
             ]
         }];
+    el[1].data = el[0].data;
   </script>
 
 </body>

--- a/nvd3-behavior.html
+++ b/nvd3-behavior.html
@@ -17,7 +17,9 @@
        */
       data: {
         type: Array,
-        value: [],
+        value: function () {
+          return [];
+        },
         observer: '_dataChanged'
       },
 
@@ -70,11 +72,13 @@
        */
       margin: {
         type: Object,
-        value: {
-          "left": null,
-          "right": null,
-          "top": null,
-          "bottom": null
+        value: function () {
+          return {
+            left: null,
+            right: null,
+            top: null,
+            bottom: null
+          };
         }
       },
 
@@ -217,12 +221,6 @@
       }
     },
 
-    getViewBox: function (width, extraWidth, height, flexSize) {
-      if (flexSize) {
-        return '0 0 ' + (width + extraWidth) + ' ' + height;
-      }
-    },
-
     /**
      * Observer for setting text of no data.
      */
@@ -297,30 +295,25 @@
      * Generate and attach the chart;
      */
     generateChart: function() {
-      var chart = this._chart;
-      var data = this.data;
-      var svg = this.svg;
-      var autoResize = this.autoResize;
-      var that = this;
-
       nv.addGraph(function() {
-        d3.select(svg)
-          .datum(data)
-          .call(chart);
+        d3.select(this.svg)
+          .datum(this.data)
+          .call(this._chart);
 
-        if (that.flexSize) {
-          d3.select(svg)
-            .attr('width', that.viewBoxWidth + that.extraViewBoxWidth)
-            .attr('height', that.viewBoxHeight);
+        if (this.flexSize) {
+          d3.select(this.svg)
+            .attr('width', this.viewBoxWidth + this.extraViewBoxWidth)
+            .attr('height', this.viewBoxHeight);
+          this._chart.update();
         }
 
-        that._set_tooltipId(chart.tooltip.id());
-        return chart;
-      });
+        this._set_tooltipId(this._chart.tooltip.id());
+        return this._chart;
+      }.bind(this));
     },
 
     ready: function() {
-      this.set('svg', this.$$('svg'));
+      this.set('svg', this.$.svg);
       this.scopeSubtree(this.$.svg, true);
     },
 

--- a/nvd3-donut.html
+++ b/nvd3-donut.html
@@ -48,7 +48,7 @@ Data Format:
 
     </style>
     <!-- We need to put svg tag inside a div to set correct margins -->
-    <div id="container">
+    <div>
       <svg id="svg"></svg>
     </div>
   </template>

--- a/nvd3-donut.html
+++ b/nvd3-donut.html
@@ -48,8 +48,8 @@ Data Format:
 
     </style>
     <!-- We need to put svg tag inside a div to set correct margins -->
-    <div>
-      <svg id="svg" viewBox$="{{ getViewBox(viewBoxWidth, extraViewBoxWidth, viewBoxHeight, flexSize) }}"></svg>
+    <div id="container">
+      <svg id="svg"></svg>
     </div>
   </template>
 
@@ -64,14 +64,13 @@ Data Format:
         _chart: {
           type: Object,
           value: function() {
-            var that = this;
             return nv.models.pieChart()
               .x(function(d) {
-                return d[that.xProp];
-              })
+                return d[this.xProp];
+              }.bind(this))
               .y(function(d) {
-                return d[that.yProp];
-              })
+                return d[this.yProp];
+              }.bind(this))
               .donut(true);
           }
         },
@@ -249,14 +248,6 @@ Data Format:
       */
       _selectionChanged: function() {
           this.fire('slice-selected', this.selection);
-      },
-
-      attached: function () {
-        if (this.flexSize) {
-          this._chart
-            .height(this.viewBoxHeight)
-            .width(this.viewBoxWidth);
-        }
       }
     });
   </script>

--- a/nvd3-sunburst.html
+++ b/nvd3-sunburst.html
@@ -92,7 +92,7 @@ Data Format:
   <template>
     <style include="nvd3-shared-styles"></style>
     <!-- We need to put svg tag inside a div to set correct margins -->
-    <div>
+    <div id="container">
       <svg id="svg"></svg>
     </div>
   </template>
@@ -108,7 +108,7 @@ Data Format:
         _chart: {
           type: Object,
           value: function() {
-            return  nv.models.sunburstChart();
+            return nv.models.sunburstChart();
           }
         },
         mode: {

--- a/nvd3-sunburst.html
+++ b/nvd3-sunburst.html
@@ -92,7 +92,7 @@ Data Format:
   <template>
     <style include="nvd3-shared-styles"></style>
     <!-- We need to put svg tag inside a div to set correct margins -->
-    <div id="container">
+    <div>
       <svg id="svg"></svg>
     </div>
   </template>


### PR DESCRIPTION
nvd3-behavior
- drop `getViewBox()`
- `generateChart()` / `nv.addGraph()` - bind function context to element to avoid `that`.
- Use Polymer automatic node finding to find svg element
- Bug: `data` is bound to global array, make instance-specific
- Bug: `margin` is bound to global object, make instance-specific

nvd3-donut
- NVD3/D3 latest versions does not seem to need to sync internal
  height/width with `<svg>` height/width, drop `attached`
- Camel case attributes such as `viewBox` gets lowercased with Polymer, needs to
  be set with `setAttribute()` or similar but is not needed for now anyway.
- Bind context in `_chart` default value function to avoid `that`
- Add `container` id to containing div for uniformity

demo - nvd3-donut, nvd3-sunburst
- Use `iron-flex-layout` classes to demo flexSize
- Add demo instance for flexSize

bower.json
- Add `iron-flex-layout` dependency